### PR TITLE
壁抜けバグ修正

### DIFF
--- a/Assets/Scripts/MapMove/PlayerController.cs
+++ b/Assets/Scripts/MapMove/PlayerController.cs
@@ -13,9 +13,9 @@ public class PlayerController : MonoBehaviour
     private Transform _playerTransform;
     private InputSetting _inputSetting;
     public Vector2Int LastInputVector { get; private set; }
-    
+
     public Vector2Int Direction { get; private set; }
-    
+
     private void Start()
     {
         OnStart();
@@ -27,18 +27,32 @@ public class PlayerController : MonoBehaviour
         _playerTransform = transform;
     }
 
-    // Update is called once per frame
     void Update()
     {
         if (_canInput)
         {
             LastInputVector = GetInputVector();
+            _startPosition = GetGridPosition();
             if (LastInputVector != Vector2Int.zero)
             {
-                _canInput = false;
                 Direction = LastInputVector;
+                if (LastInputVector == Vector2Int.up)
+                {
+                    _canInput = _startPosition.y == mapDataController.GetMapSize().y - 1;
+                }
+                else if (LastInputVector == Vector2Int.left)
+                {
+                    _canInput = _startPosition.x == 0;
+                }
+                else if (LastInputVector == Vector2Int.down)
+                {
+                    _canInput = _startPosition.y == 0;
+                }
+                else if (LastInputVector == Vector2Int.right)
+                {
+                    _canInput = _startPosition.x == mapDataController.GetMapSize().x - 1;
+                }
             }
-            _startPosition = GetGridPosition();
             _targetPosition = mapDataController.ConvertGridPosition(_startPosition + LastInputVector);
         }
         else
@@ -83,7 +97,7 @@ public class PlayerController : MonoBehaviour
     {
         Vector3 targetVector = new Vector3(_targetPosition.x, _targetPosition.y, 0);
         if (Vector3.Distance(targetVector, _playerTransform.position) >= allowDistance) return;
-        
+
         _playerTransform.position = targetVector;
         MovePrepare();
     }
@@ -103,7 +117,7 @@ public class PlayerController : MonoBehaviour
         _playerTransform.position = new Vector3(_startPosition.x, _startPosition.y, 0);
         MovePrepare();
     }
-    
+
     public Vector2Int GetGridPosition()
     {
         return new Vector2Int(Mathf.RoundToInt(transform.position.x), Mathf.RoundToInt(transform.position.y));

--- a/Assets/Scripts/MapMove/PlayerController.cs
+++ b/Assets/Scripts/MapMove/PlayerController.cs
@@ -36,22 +36,7 @@ public class PlayerController : MonoBehaviour
             if (LastInputVector != Vector2Int.zero)
             {
                 Direction = LastInputVector;
-                if (LastInputVector == Vector2Int.up)
-                {
-                    _canInput = _startPosition.y == mapDataController.GetMapSize().y - 1;
-                }
-                else if (LastInputVector == Vector2Int.left)
-                {
-                    _canInput = _startPosition.x == 0;
-                }
-                else if (LastInputVector == Vector2Int.down)
-                {
-                    _canInput = _startPosition.y == 0;
-                }
-                else if (LastInputVector == Vector2Int.right)
-                {
-                    _canInput = _startPosition.x == mapDataController.GetMapSize().x - 1;
-                }
+                _canInput = mapDataController.IsGridPositionOutOfRange(_startPosition+LastInputVector);
             }
             _targetPosition = mapDataController.ConvertGridPosition(_startPosition + LastInputVector);
         }

--- a/Assets/Scripts/MapMove/PlayerControllerWithCollider.cs
+++ b/Assets/Scripts/MapMove/PlayerControllerWithCollider.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 [RequireComponent(typeof(BoxCollider2D))]

--- a/Assets/Scripts/ScriptEngine/MapEngine/MapDataController.cs
+++ b/Assets/Scripts/ScriptEngine/MapEngine/MapDataController.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;

--- a/Assets/Scripts/ScriptEngine/ObjectEngine.cs
+++ b/Assets/Scripts/ScriptEngine/ObjectEngine.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.IO;
 using System.Linq;
 using System.Collections.Generic;


### PR DESCRIPTION
### 修正仕様
- 入力方向をGetInputVector()で計算した後に、タイルマップの縁に立っているのにタイル外の方向に進もうとしていることがよくないと考え、その場合は入力受付モードから移動モードに変わらないようにした。
- GetInputVector()内で、タイルマップの縁に立っているのにタイル外の方向に進もうとしている時にVector.zeroを返すような処理にすると、CharacterMoveVisualでキャラクターの移動アニメーションを再生できないので、それは行わなかった。