### PR TITLE
Pauseの動作不良の修正

### DIFF
--- a/Assets/Prefabs/TextWindow.prefab
+++ b/Assets/Prefabs/TextWindow.prefab
@@ -327,6 +327,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 75cb3e56cfa86074d8e914f78478ce64, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  _mainTextObject: {fileID: 7544126218790116360}
   animator: {fileID: 1203836122537559927}
   nextPageIcon: {fileID: 3643819247776579852}
   iconObject: {fileID: 915160964267895250}

--- a/Assets/Scripts/MapMove/PlayerController.cs
+++ b/Assets/Scripts/MapMove/PlayerController.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 // CollisionEnterを機能させるために必要
 [RequireComponent(typeof(Rigidbody2D))]
@@ -105,6 +106,7 @@ public class PlayerController : MonoBehaviour
 
     public Vector2Int GetGridPosition()
     {
+        DebugLogger.Log("currentSceneName (GetGridPosition()): "+SceneManager.GetActiveScene().name);
         return new Vector2Int(Mathf.RoundToInt(transform.position.x), Mathf.RoundToInt(transform.position.y));
     }
 }

--- a/Assets/Scripts/MapMove/PlayerController.cs
+++ b/Assets/Scripts/MapMove/PlayerController.cs
@@ -16,6 +16,7 @@ public class PlayerController : MonoBehaviour
     public Vector2Int LastInputVector { get; private set; }
 
     public Vector2Int Direction { get; private set; }
+    private string startSceneName;
 
     private void Start()
     {
@@ -26,6 +27,7 @@ public class PlayerController : MonoBehaviour
     {
         _inputSetting = InputSetting.Load();
         _playerTransform = transform;
+        startSceneName = SceneManager.GetActiveScene().name;
     }
 
     void Update()
@@ -37,7 +39,7 @@ public class PlayerController : MonoBehaviour
             if (LastInputVector != Vector2Int.zero)
             {
                 Direction = LastInputVector;
-                _canInput = mapDataController.IsGridPositionOutOfRange(_startPosition+LastInputVector);
+                _canInput = mapDataController.IsGridPositionOutOfRange(_startPosition + LastInputVector);
             }
             _targetPosition = mapDataController.ConvertGridPosition(_startPosition + LastInputVector);
         }
@@ -106,7 +108,11 @@ public class PlayerController : MonoBehaviour
 
     public Vector2Int GetGridPosition()
     {
-        DebugLogger.Log("currentSceneName (GetGridPosition()): "+SceneManager.GetActiveScene().name);
-        return new Vector2Int(Mathf.RoundToInt(transform.position.x), Mathf.RoundToInt(transform.position.y));
+        if (startSceneName == SceneManager.GetActiveScene().name)
+        {
+            DebugLogger.Log("currentSceneName (GetGridPosition()): " + SceneManager.GetActiveScene().name);
+            return new Vector2Int(Mathf.RoundToInt(transform.position.x), Mathf.RoundToInt(transform.position.y));
+        }
+        return new();
     }
 }

--- a/Assets/Scripts/MapMove/PlayerController.cs
+++ b/Assets/Scripts/MapMove/PlayerController.cs
@@ -110,7 +110,6 @@ public class PlayerController : MonoBehaviour
     {
         if (startSceneName == SceneManager.GetActiveScene().name)
         {
-            DebugLogger.Log("currentSceneName (GetGridPosition()): " + SceneManager.GetActiveScene().name);
             return new Vector2Int(Mathf.RoundToInt(transform.position.x), Mathf.RoundToInt(transform.position.y));
         }
         return new();

--- a/Assets/Scripts/Pause.cs
+++ b/Assets/Scripts/Pause.cs
@@ -10,13 +10,6 @@ public class Pause : MonoBehaviour
     void Start()
     {
         startSceneName = SceneManager.GetActiveScene().name;
-        DebugLogger.Log("startSceneName: " + startSceneName);
-        string text = "Behaviours: ";
-        foreach (Behaviour pauseScript in pauseScripts)
-        {
-            text += pauseScript.name + ",  ";
-        }
-        DebugLogger.Log(text);
     }
 
     public void PauseAll()
@@ -25,8 +18,6 @@ public class Pause : MonoBehaviour
         {
             foreach (Behaviour behaviour in pauseScripts)
             {
-                // DebugLogger.Log("startSceneName: " + startSceneName);
-                // DebugLogger.Log("currentSceneName: " + SceneManager.GetActiveScene().name);
                 behaviour.enabled = false;
             }
 
@@ -39,8 +30,6 @@ public class Pause : MonoBehaviour
         {
             foreach (Behaviour behaviour in pauseScripts)
             {
-                // DebugLogger.Log("startSceneName: " + startSceneName);
-                // DebugLogger.Log("currentSceneName: " + SceneManager.GetActiveScene().name);
                 behaviour.enabled = true;
             }
 

--- a/Assets/Scripts/Pause.cs
+++ b/Assets/Scripts/Pause.cs
@@ -1,26 +1,49 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 public class Pause : MonoBehaviour
 {
     [SerializeField] private List<Behaviour> pauseScripts;
+    private string startSceneName;
+    void Start()
+    {
+        startSceneName = SceneManager.GetActiveScene().name;
+        DebugLogger.Log("startSceneName: " + startSceneName);
+        string text = "Behaviours: ";
+        foreach (Behaviour pauseScript in pauseScripts)
+        {
+            text += pauseScript.name + ",  ";
+        }
+        DebugLogger.Log(text);
+    }
 
     public void PauseAll()
     {
-        foreach (Behaviour behaviour in pauseScripts)
+        if (startSceneName == SceneManager.GetActiveScene().name)
         {
-            DebugLogger.Log(behaviour);
-            DebugLogger.Log($"{UnityEngine.SceneManagement.SceneManager.GetActiveScene().name}, behaviour : {behaviour == null}");
-            behaviour.enabled = false;
+            foreach (Behaviour behaviour in pauseScripts)
+            {
+                // DebugLogger.Log("startSceneName: " + startSceneName);
+                // DebugLogger.Log("currentSceneName: " + SceneManager.GetActiveScene().name);
+                behaviour.enabled = false;
+            }
+
         }
     }
 
     public void UnPauseAll()
     {
-        foreach (Behaviour behaviour in pauseScripts)
+        if (startSceneName == SceneManager.GetActiveScene().name)
         {
-            behaviour.enabled = true;
+            foreach (Behaviour behaviour in pauseScripts)
+            {
+                // DebugLogger.Log("startSceneName: " + startSceneName);
+                // DebugLogger.Log("currentSceneName: " + SceneManager.GetActiveScene().name);
+                behaviour.enabled = true;
+            }
+
         }
     }
 }

--- a/Assets/Scripts/ScriptEngine/ObjectEngine.cs
+++ b/Assets/Scripts/ScriptEngine/ObjectEngine.cs
@@ -39,8 +39,8 @@ public class ObjectEngine : MonoBehaviour
         mapDataController.SetChange(ResetAction);
         ResetAction();
         PlayerMove(changedPos);
+        // pause = GameObject.Find("Pause").GetComponent<Pause>();
     }
-    
     private void ResetAction()
     {
         Initialize(_mapName, mapDataController.GetMapSize().x, mapDataController.GetMapSize().y);
@@ -120,6 +120,7 @@ public class ObjectEngine : MonoBehaviour
             runFlag = false;
             foreach (ObjectData aroundObjectData in aroundObjectDatas)
             {
+                DebugLogger.Log("aroundObjectData: "+aroundObjectData);
                 await Call(aroundObjectData, 1, 2);
             }
             
@@ -219,6 +220,7 @@ public class ObjectEngine : MonoBehaviour
                 break;
             case "SearchGame":
                 DebugLogger.Log("SearchGame", DebugLogger.Colors.Green);
+                DebugLogger.Log("CurrentSceneName(ObjectEngine): "+SceneManager.GetActiveScene().name);
                 await SceneChange("SearchGame");
                 break;
             case "TimingGame":

--- a/Assets/Scripts/ScriptEngine/ObjectEngine.cs
+++ b/Assets/Scripts/ScriptEngine/ObjectEngine.cs
@@ -120,7 +120,6 @@ public class ObjectEngine : MonoBehaviour
             runFlag = false;
             foreach (ObjectData aroundObjectData in aroundObjectDatas)
             {
-                DebugLogger.Log("aroundObjectData: "+aroundObjectData);
                 await Call(aroundObjectData, 1, 2);
             }
             

--- a/Assets/Scripts/Text/MainTextDrawer.cs
+++ b/Assets/Scripts/Text/MainTextDrawer.cs
@@ -1,8 +1,5 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 using TMPro;
-using System.Diagnostics;
 
 [RequireComponent(typeof(TextMeshProUGUI))]
 public class MainTextDrawer : MonoBehaviour

--- a/Assets/Scripts/Text/MainTextDrawer.cs
+++ b/Assets/Scripts/Text/MainTextDrawer.cs
@@ -2,11 +2,12 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using TMPro;
+using System.Diagnostics;
 
 [RequireComponent(typeof(TextMeshProUGUI))]
 public class MainTextDrawer : MonoBehaviour
 {
-    private TextMeshProUGUI _mainTextObject;
+    [SerializeField] private TextMeshProUGUI _mainTextObject;
 
     [SerializeField] Animator animator;
     [SerializeField] GameObject nextPageIcon;
@@ -17,7 +18,6 @@ public class MainTextDrawer : MonoBehaviour
 
     public void Initialize()
     {
-        _mainTextObject = GetComponent<TextMeshProUGUI>();
         _mainTextObject.maxVisibleCharacters = 0;
         _displayedSentenceLength = -1;
     }
@@ -64,6 +64,8 @@ public class MainTextDrawer : MonoBehaviour
 
     public bool AllowChangeLine()
     {
+        DebugLogger.Log("_mainTextObject: "+_mainTextObject);
+        DebugLogger.Log("_mainTextObject.GetParsedText(): "+_mainTextObject.GetParsedText());
         string sentence = _mainTextObject.GetParsedText();
         return _displayedSentenceLength > sentence.Length - 1;
     }

--- a/Assets/Scripts/Text/MainTextDrawer.cs
+++ b/Assets/Scripts/Text/MainTextDrawer.cs
@@ -64,8 +64,6 @@ public class MainTextDrawer : MonoBehaviour
 
     public bool AllowChangeLine()
     {
-        DebugLogger.Log("_mainTextObject: "+_mainTextObject);
-        DebugLogger.Log("_mainTextObject.GetParsedText(): "+_mainTextObject.GetParsedText());
         string sentence = _mainTextObject.GetParsedText();
         return _displayedSentenceLength > sentence.Length - 1;
     }

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -26,4 +26,7 @@ EditorBuildSettings:
   - enabled: 1
     path: Assets/Scenes/tessen_room.unity
     guid: cad76efb487c78b4ba6375b5666c3684
+  - enabled: 1
+    path: Assets/Scenes/SearchGame.unity
+    guid: f922ad811485648b481f6c50a4716548
   m_configObjects: {}


### PR DESCRIPTION
### 変更点

- SearchGameがBuildSettingsに入っていないとScene遷移ができなかったので追加した.
- PauseとPlayerController.GetGridPosition()が、Start()の時点でのSceneと関数実行時のSceneが一致していないと動かないようにした。
  - LoadScene()が非同期のため、Sceneが遷移した後にPlayerなどのDontDestroyでないオブジェクトをPauseしてしまうときに`MissingReferenceException: The object of type 'PlayerControllerWithCollider' has been destroyed but you are still trying to access it.`のようなエラーが発生するため。