### PR TITLE
マップ中のミニゲーム発生箇所に自動でキラキラを配置するようにした

### DIFF
--- a/Assets/Prefabs/MapEngine.prefab
+++ b/Assets/Prefabs/MapEngine.prefab
@@ -156,6 +156,7 @@ Transform:
   - {fileID: 3898016017389061615}
   - {fileID: 1085107381286804336}
   - {fileID: 1836877590459017523}
+  - {fileID: 7375599533976224524}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!156049354 &494499326421320151
@@ -186,6 +187,7 @@ MonoBehaviour:
   frontTilemap: {fileID: 177687494444778665}
   middleTilemap: {fileID: 7753607223690526146}
   backTilemap: {fileID: 1974347116033169273}
+  twinkleTile: {fileID: 1421071763039742668}
   clearTile: {fileID: 11400000, guid: 0702332183b8e4a509042ac29a7ed3b3, type: 2}
   tileMapping: {fileID: 11400000, guid: 6c280859c7d80e4459e2aba6f36b8049, type: 2}
   mapDataController: {fileID: 975195158262473547}
@@ -434,6 +436,126 @@ TilemapRenderer:
   m_SortingLayerID: 0
   m_SortingLayer: 0
   m_SortingOrder: 2
+  m_ChunkSize: {x: 32, y: 32, z: 32}
+  m_ChunkCullingBounds: {x: 0, y: 0, z: 0}
+  m_MaxChunkCount: 16
+  m_MaxFrameAge: 16
+  m_SortOrder: 0
+  m_Mode: 0
+  m_DetectChunkCullingBounds: 0
+  m_MaskInteraction: 0
+--- !u!1 &7653233458329599082
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7375599533976224524}
+  - component: {fileID: 1421071763039742668}
+  - component: {fileID: 8724009040585764045}
+  m_Layer: 0
+  m_Name: Tilemap (4)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7375599533976224524
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7653233458329599082}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4941413016671325715}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1839735485 &1421071763039742668
+Tilemap:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7653233458329599082}
+  m_Enabled: 1
+  m_Tiles: {}
+  m_AnimatedTiles: {}
+  m_TileAssetArray: []
+  m_TileSpriteArray: []
+  m_TileMatrixArray: []
+  m_TileColorArray: []
+  m_TileObjectToInstantiateArray: []
+  m_AnimationFrameRate: 1
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Origin: {x: 0, y: 0, z: 0}
+  m_Size: {x: 0, y: 0, z: 1}
+  m_TileAnchor: {x: 0, y: 0, z: 0}
+  m_TileOrientation: 0
+  m_TileOrientationMatrix:
+    e00: 1
+    e01: 0
+    e02: 0
+    e03: 0
+    e10: 0
+    e11: 1
+    e12: 0
+    e13: 0
+    e20: 0
+    e21: 0
+    e22: 1
+    e23: 0
+    e30: 0
+    e31: 0
+    e32: 0
+    e33: 1
+--- !u!483693784 &8724009040585764045
+TilemapRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7653233458329599082}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 0
+  m_ReflectionProbeUsage: 0
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 8
   m_ChunkSize: {x: 32, y: 32, z: 32}
   m_ChunkCullingBounds: {x: 0, y: 0, z: 0}
   m_MaxChunkCount: 16

--- a/Assets/Scripts/ScriptEngine/MapEngine/MapEngine.cs
+++ b/Assets/Scripts/ScriptEngine/MapEngine/MapEngine.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using UnityEngine;
 using UnityEngine.Tilemaps;
 
@@ -10,6 +8,7 @@ public class MapEngine : MonoBehaviour
     [SerializeField] private Tilemap frontTilemap;
     [SerializeField] private Tilemap middleTilemap;
     [SerializeField] private Tilemap backTilemap;
+    [SerializeField] private Tilemap twinkleTile;
     [SerializeField] private Tile clearTile;
     public TileMapping tileMapping;
     
@@ -77,6 +76,11 @@ public class MapEngine : MonoBehaviour
     private void PutFrontStyleTile(Vector3Int position, Dictionary<char, TileBase> tileDictionary)
     {
         PutSingleTile(frontTilemap, position, tileDictionary, mapDataController.GetStyleFrontChar(position));
+    }
+
+    public void PutTwinkleTile(Vector3Int position, Dictionary<char, TileBase> tileDictionary)
+    {
+        PutSingleTile(twinkleTile, position, tileDictionary, '?');
     }
     
     private void PutSingleTile(Tilemap tilemap, Vector3Int position, Dictionary<char, TileBase> tileDictionary, char tileChar)

--- a/Assets/Scripts/ScriptEngine/ObjectEngine.cs
+++ b/Assets/Scripts/ScriptEngine/ObjectEngine.cs
@@ -82,6 +82,7 @@ public class ObjectEngine : MonoBehaviour
                 else
                 {
                     _eventObjects[location.Position.x][location.Position.y].Add(objectData);
+                    PutMiniGameTwinkle(objectData);
                 }
             }
         }
@@ -172,7 +173,7 @@ public class ObjectEngine : MonoBehaviour
             {
                 DebugLogger.Log(x.Key + " : expected: " + x.Value + " : actual:" + FlagManager.Instance.HasFlag(x.Key), DebugLogger.Colors.Blue);
             }
-            if (objectData.FlagCondition.Flag is not null && objectData.FlagCondition.Flag.Any(x => FlagManager.Instance.HasFlag(x.Key) != x.Value))
+            if (IsFlagsInsufficient(objectData))
             {
                 return; // continue;
             }
@@ -254,6 +255,11 @@ public class ObjectEngine : MonoBehaviour
         }
     }
 
+    private bool IsFlagsInsufficient(ObjectData objectData)
+    {
+        return objectData.FlagCondition.Flag is not null && objectData.FlagCondition.Flag.Any(x => FlagManager.Instance.HasFlag(x.Key) != x.Value);
+    }
+
     private void SetNextFlag(KeyValuePair<string, bool>[] nextFlags)
     {
         foreach (KeyValuePair<string, bool> nextFlag in nextFlags)
@@ -313,5 +319,19 @@ public class ObjectEngine : MonoBehaviour
     {
         mapDataController.ChangeMapTile(mapName, layer, position, tipSign);
         mapDataController.ApplyMapChange();
+    }
+
+    private void PutMiniGameTwinkle(ObjectData objectData)
+    {
+        bool isObjectDataMiniGame = false;
+        string[] miniGameNames = new string[5] { "PaperGame", "SearchGame", "TimingGame", "Conversation Search", "Conversation Mixing" };
+        isObjectDataMiniGame = miniGameNames.Any(name => objectData.EventName.Contains(name));
+        if (isObjectDataMiniGame && !IsFlagsInsufficient(objectData))
+        {
+            foreach (Location loc in objectData.Location)
+            {
+                mapEngine.PutTwinkleTile(new Vector3Int(loc.Position.x, loc.Position.y, 0), mapEngine.tileMapping.ToDictionary());
+            }
+        }
     }
 }


### PR DESCRIPTION
- MapEngineプレハブに、新しくTilemapオブジェクトを追加した。
- ObjectEngineがミニゲーム発生オブジェクトを配置するときに、MapEngineのメソッドでキラキラも配置する仕様です。
- キラキラを配置する時の条件で、ObjectEngine中で満たしていないフラグがないかチェックする条件式をもう一度使いた買ったので、この条件式をメソッド化してそれを使い回すようにしました。