### PR TITLE
SearchGameでのみOSのカーソルが消えるようにした。

### DIFF
--- a/Assets/Scenes/SearchGame.unity
+++ b/Assets/Scenes/SearchGame.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641275, b: 0.5748172, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657844, g: 0.49641222, b: 0.57481676, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -486,6 +486,50 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 5.2479506, y: 4.419706, z: 8.530443}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1147312657
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1147312659}
+  - component: {fileID: 1147312658}
+  m_Layer: 0
+  m_Name: Initializer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1147312658
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1147312657}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 38e2c93223a2d439aad72855926e5528, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1147312659
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1147312657}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 961.8876, y: 517.18384, z: -11.6113405}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -961,3 +1005,4 @@ SceneRoots:
   - {fileID: 1832807551}
   - {fileID: 1133017294}
   - {fileID: 2031888869}
+  - {fileID: 1147312659}

--- a/Assets/Scenes/Title.unity
+++ b/Assets/Scenes/Title.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657844, g: 0.49641222, b: 0.57481676, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -2163,7 +2163,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1996724876}
   - component: {fileID: 1996724875}
-  - component: {fileID: 1996724877}
   m_Layer: 0
   m_Name: Initializer
   m_TagString: Untagged
@@ -2202,18 +2201,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!114 &1996724877
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1996724874}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: d491e8d4156674739baed18351ec435a, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
 --- !u!1 &2033599933
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/SearchGame/MouseHide.cs
+++ b/Assets/Scripts/SearchGame/MouseHide.cs
@@ -6,4 +6,9 @@ public class MouseHide : MonoBehaviour
     {
         Cursor.visible = false;
     }
+
+    void OnDisable()
+    {
+        Cursor.visible = true;
+    }
 }

--- a/Assets/Scripts/SearchGame/MouseHide.cs.meta
+++ b/Assets/Scripts/SearchGame/MouseHide.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: d491e8d4156674739baed18351ec435a
+guid: 38e2c93223a2d439aad72855926e5528
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2


### PR DESCRIPTION
今まではゲーム開始時にカーソルを隠していたが、音量調整や重ね合わせゲームなどでカーソルがなくて操作に困ったので、SearchGameの開始、終了時にOSカーソルのON/OFFを切り替えるようにした。